### PR TITLE
Handle SQL statement without additional kwargs separately

### DIFF
--- a/src/esa_geo_utils/io/_pyspark.py
+++ b/src/esa_geo_utils/io/_pyspark.py
@@ -69,8 +69,10 @@ def _get_layer(
     sql_kwargs: Optional[Dict[str, str]],
 ) -> Layer:
     """Returns a GDAL Layer from a SQL statement, name or index, or 0th layer."""
-    if sql:
+    if sql and sql_kwargs:
         return data_source.ExecuteSQL(sql, **sql_kwargs)
+    elif sql:
+        return data_source.ExecuteSQL(sql)
     elif layer:
         return data_source.GetLayer(layer)
     else:

--- a/tests/io/test__pyspark.py
+++ b/tests/io/test__pyspark.py
@@ -1,21 +1,21 @@
 """Tests for _pyspark module."""
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import pytest
 from osgeo.ogr import Layer, Open
 
-from esa_geo_utils._pyspark import _get_layer
+from esa_geo_utils.io._pyspark import _get_layer
 
 PARAMETERS = [
-    (None, None, "second", 2),
-    (None, 0, "second", 2),
-    (None, "first", "first", 2),
-    ("SELECT * FROM first WHERE id LIKE 'first_id'", None, "first", 1),
+    (None, None, None, "second", 2),
+    (None, None, 0, "second", 2),
+    (None, None, "first", "first", 2),
+    ("SELECT * FROM first WHERE id LIKE 'first_id'", None, None, "first", 1),
 ]
 
 
 @pytest.mark.parametrize(
-    "sql,layer,expected_layer_name,expected_feature_count",
+    "sql,sql_kwargs,layer,expected_layer_name,expected_feature_count",
     PARAMETERS,
     ids=[
         "No arguments",
@@ -28,13 +28,19 @@ def test__get_layer(
     fileGDB_path: str,
     sql: Optional[str],
     layer: Optional[Union[str, int]],
+    sql_kwargs: Optional[Dict[str, str]],
     expected_layer_name: str,
     expected_feature_count: int,
 ) -> None:
     """Returns expected layer name and feature count for each method."""
     data_source = Open(fileGDB_path)
 
-    _layer: Layer = _get_layer(data_source=data_source, sql=sql, layer=layer)
+    _layer: Layer = _get_layer(
+        data_source=data_source,
+        sql=sql,
+        layer=layer,
+        sql_kwargs=sql_kwargs,
+    )
 
     layer_name = _layer.GetName()
 


### PR DESCRIPTION
Closes #5 by:

- Handling the use of sql and sql and sql_kwargs separately in _get_layer
- Updating tests for _get_layer to include one for sql without sql_kwargs
