### PR TITLE
Eft defra/issue15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
-      - name: Install GDAL 3.3.2
+      - name: Install GDAL 3.4.0
         run: |
           sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
           sudo apt-get update
-          sudo apt-get install -y libgdal-dev=3.3.2+dfsg-2~focal2
+          sudo apt-get install -y libgdal-dev=3.4.0+dfsg-1~focal0
       - name: Install nox
         run: python -m pip install nox==2021.6.12
       - name: Install poetry

--- a/poetry.lock
+++ b/poetry.lock
@@ -19,29 +19,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.2.0"
+version = "21.4.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
-
-[[package]]
-name = "backports.entry-points-selectable"
-version = "1.1.1"
-description = "Compatibility shim providing selectable entry points for older implementations"
-category = "dev"
-optional = false
-python-versions = ">=2.7"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "bandit"
@@ -219,11 +207,11 @@ pipenv = ["pipenv"]
 
 [[package]]
 name = "filelock"
-version = "3.4.0"
+version = "3.4.2"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
@@ -359,7 +347,7 @@ flake8 = "*"
 
 [[package]]
 name = "gdal"
-version = "3.3.2"
+version = "3.4.0"
 description = "GDAL: Geospatial Data Abstraction Library"
 category = "main"
 optional = false
@@ -407,7 +395,7 @@ typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.10\"
 
 [[package]]
 name = "identify"
-version = "2.4.0"
+version = "2.4.1"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -530,11 +518,11 @@ tox_to_nox = ["jinja2", "tox"]
 
 [[package]]
 name = "numpy"
-version = "1.21.4"
+version = "1.22.0"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
-python-versions = ">=3.7,<3.11"
+python-versions = ">=3.8"
 
 [[package]]
 name = "packaging"
@@ -549,7 +537,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.3.4"
+version = "1.3.5"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
@@ -586,11 +574,11 @@ python-versions = ">=2.6"
 
 [[package]]
 name = "platformdirs"
-version = "2.4.0"
+version = "2.4.1"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
@@ -774,7 +762,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "requests"
-version = "2.26.0"
+version = "2.27.0"
 description = "Python HTTP for Humans."
 category = "dev"
 optional = false
@@ -875,7 +863,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "1.2.2"
+version = "1.2.3"
 description = "A lil' TOML parser"
 category = "dev"
 optional = false
@@ -904,14 +892,13 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.10.0"
+version = "20.13.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
-"backports.entry-points-selectable" = ">=1.0.4"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.2,<4"
 platformdirs = ">=2,<3"
@@ -924,7 +911,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "61e72fbc286dc0ce01cffb8273797e61a2a3e76a0fc3e89b66e16e5837c98591"
+content-hash = "0e0ba6bbd859bee60a960ff8b30ebf6e97f17031273345701fbe056f88815369"
 
 [metadata.files]
 argcomplete = [
@@ -936,12 +923,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
-    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
-]
-"backports.entry-points-selectable" = [
-    {file = "backports.entry_points_selectable-1.1.1-py2.py3-none-any.whl", hash = "sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b"},
-    {file = "backports.entry_points_selectable-1.1.1.tar.gz", hash = "sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386"},
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 bandit = [
     {file = "bandit-1.7.1-py3-none-any.whl", hash = "sha256:f5acd838e59c038a159b5c621cf0f8270b279e884eadd7b782d7491c02add0d4"},
@@ -1050,8 +1033,8 @@ dparse = [
     {file = "dparse-0.5.1.tar.gz", hash = "sha256:a1b5f169102e1c894f9a7d5ccf6f9402a836a5d24be80a986c7ce9eaed78f367"},
 ]
 filelock = [
-    {file = "filelock-3.4.0-py3-none-any.whl", hash = "sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8"},
-    {file = "filelock-3.4.0.tar.gz", hash = "sha256:93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4"},
+    {file = "filelock-3.4.2-py3-none-any.whl", hash = "sha256:cf0fc6a2f8d26bd900f19bf33915ca70ba4dd8c56903eeb14e1e7a2fd7590146"},
+    {file = "filelock-3.4.2.tar.gz", hash = "sha256:38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80"},
 ]
 fiona = [
     {file = "Fiona-1.8.20-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:02880556540e36ad6aac97687799d9b3093c354787a47bc0e73026c7fc15f1b3"},
@@ -1096,7 +1079,7 @@ flake8-polyfill = [
     {file = "flake8_polyfill-1.0.2-py2.py3-none-any.whl", hash = "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9"},
 ]
 gdal = [
-    {file = "GDAL-3.3.2.tar.gz", hash = "sha256:b74d310cc837cfc45b7dfa82eb7cd7ca7d2c2c2114bc31db66e01cc1ea6d0124"},
+    {file = "GDAL-3.4.0.tar.gz", hash = "sha256:05c92a0fd262a9600bc6f896485e7f5f575f354957847ceb9fed7c1c616c189e"},
 ]
 geopandas = [
     {file = "geopandas-0.10.2-py2.py3-none-any.whl", hash = "sha256:1722853464441b603d9be3d35baf8bde43831424a891e82a8545eb8997b65d6c"},
@@ -1111,8 +1094,8 @@ gitpython = [
     {file = "GitPython-3.1.24.tar.gz", hash = "sha256:df83fdf5e684fef7c6ee2c02fc68a5ceb7e7e759d08b694088d0cacb4eba59e5"},
 ]
 identify = [
-    {file = "identify-2.4.0-py2.py3-none-any.whl", hash = "sha256:eba31ca80258de6bb51453084bff4a923187cd2193b9c13710f2516ab30732cc"},
-    {file = "identify-2.4.0.tar.gz", hash = "sha256:a33ae873287e81651c7800ca309dc1f84679b763c9c8b30680e16fbfa82f0107"},
+    {file = "identify-2.4.1-py2.py3-none-any.whl", hash = "sha256:0192893ff68b03d37fed553e261d4a22f94ea974093aefb33b29df2ff35fed3c"},
+    {file = "identify-2.4.1.tar.gz", hash = "sha256:64d4885e539f505dd8ffb5e93c142a1db45480452b1594cacd3e91dca9a984e9"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -1176,66 +1159,59 @@ nox = [
     {file = "nox-2021.10.1.tar.gz", hash = "sha256:0a1c735d5e90fa234046b58a5ad61d08bc13ae77ab213da9b58d5cc2d25023ae"},
 ]
 numpy = [
-    {file = "numpy-1.21.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8890b3360f345e8360133bc078d2dacc2843b6ee6059b568781b15b97acbe39f"},
-    {file = "numpy-1.21.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:69077388c5a4b997442b843dbdc3a85b420fb693ec8e33020bb24d647c164fa5"},
-    {file = "numpy-1.21.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e89717274b41ebd568cd7943fc9418eeb49b1785b66031bc8a7f6300463c5898"},
-    {file = "numpy-1.21.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b78ecfa070460104934e2caf51694ccd00f37d5e5dbe76f021b1b0b0d221823"},
-    {file = "numpy-1.21.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:615d4e328af7204c13ae3d4df7615a13ff60a49cb0d9106fde07f541207883ca"},
-    {file = "numpy-1.21.4-cp310-cp310-win_amd64.whl", hash = "sha256:1403b4e2181fc72664737d848b60e65150f272fe5a1c1cbc16145ed43884065a"},
-    {file = "numpy-1.21.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:74b85a17528ca60cf98381a5e779fc0264b4a88b46025e6bcbe9621f46bb3e63"},
-    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92aafa03da8658609f59f18722b88f0a73a249101169e28415b4fa148caf7e41"},
-    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5d95668e727c75b3f5088ec7700e260f90ec83f488e4c0aaccb941148b2cd377"},
-    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5162ec777ba7138906c9c274353ece5603646c6965570d82905546579573f73"},
-    {file = "numpy-1.21.4-cp37-cp37m-win32.whl", hash = "sha256:81225e58ef5fce7f1d80399575576fc5febec79a8a2742e8ef86d7b03beef49f"},
-    {file = "numpy-1.21.4-cp37-cp37m-win_amd64.whl", hash = "sha256:32fe5b12061f6446adcbb32cf4060a14741f9c21e15aaee59a207b6ce6423469"},
-    {file = "numpy-1.21.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c449eb870616a7b62e097982c622d2577b3dbc800aaf8689254ec6e0197cbf1e"},
-    {file = "numpy-1.21.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2e4ed57f45f0aa38beca2a03b6532e70e548faf2debbeb3291cfc9b315d9be8f"},
-    {file = "numpy-1.21.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1247ef28387b7bb7f21caf2dbe4767f4f4175df44d30604d42ad9bd701ebb31f"},
-    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:34f3456f530ae8b44231c63082c8899fe9c983fd9b108c997c4b1c8c2d435333"},
-    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4c9c23158b87ed0e70d9a50c67e5c0b3f75bcf2581a8e34668d4e9d7474d76c6"},
-    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4799be6a2d7d3c33699a6f77201836ac975b2e1b98c2a07f66a38f499cb50ce"},
-    {file = "numpy-1.21.4-cp38-cp38-win32.whl", hash = "sha256:bc988afcea53e6156546e5b2885b7efab089570783d9d82caf1cfd323b0bb3dd"},
-    {file = "numpy-1.21.4-cp38-cp38-win_amd64.whl", hash = "sha256:170b2a0805c6891ca78c1d96ee72e4c3ed1ae0a992c75444b6ab20ff038ba2cd"},
-    {file = "numpy-1.21.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:fde96af889262e85aa033f8ee1d3241e32bf36228318a61f1ace579df4e8170d"},
-    {file = "numpy-1.21.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c885bfc07f77e8fee3dc879152ba993732601f1f11de248d4f357f0ffea6a6d4"},
-    {file = "numpy-1.21.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9e6f5f50d1eff2f2f752b3089a118aee1ea0da63d56c44f3865681009b0af162"},
-    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad010846cdffe7ec27e3f933397f8a8d6c801a48634f419e3d075db27acf5880"},
-    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c74c699b122918a6c4611285cc2cad4a3aafdb135c22a16ec483340ef97d573c"},
-    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9864424631775b0c052f3bd98bc2712d131b3e2cd95d1c0c68b91709170890b0"},
-    {file = "numpy-1.21.4-cp39-cp39-win32.whl", hash = "sha256:b1e2312f5b8843a3e4e8224b2b48fe16119617b8fc0a54df8f50098721b5bed2"},
-    {file = "numpy-1.21.4-cp39-cp39-win_amd64.whl", hash = "sha256:e3c3e990274444031482a31280bf48674441e0a5b55ddb168f3a6db3e0c38ec8"},
-    {file = "numpy-1.21.4-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a3deb31bc84f2b42584b8c4001c85d1934dbfb4030827110bc36bfd11509b7bf"},
-    {file = "numpy-1.21.4.zip", hash = "sha256:e6c76a87633aa3fa16614b61ccedfae45b91df2767cf097aa9c933932a7ed1e0"},
+    {file = "numpy-1.22.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d22662b4b10112c545c91a0741f2436f8ca979ab3d69d03d19322aa970f9695"},
+    {file = "numpy-1.22.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:11a1f3816ea82eed4178102c56281782690ab5993251fdfd75039aad4d20385f"},
+    {file = "numpy-1.22.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5dc65644f75a4c2970f21394ad8bea1a844104f0fe01f278631be1c7eae27226"},
+    {file = "numpy-1.22.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42c16cec1c8cf2728f1d539bd55aaa9d6bb48a7de2f41eb944697293ef65a559"},
+    {file = "numpy-1.22.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a97e82c39d9856fe7d4f9b86d8a1e66eff99cf3a8b7ba48202f659703d27c46f"},
+    {file = "numpy-1.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:e41e8951749c4b5c9a2dc5fdbc1a4eec6ab2a140fdae9b460b0f557eed870f4d"},
+    {file = "numpy-1.22.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:bece0a4a49e60e472a6d1f70ac6cdea00f9ab80ff01132f96bd970cdd8a9e5a9"},
+    {file = "numpy-1.22.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:818b9be7900e8dc23e013a92779135623476f44a0de58b40c32a15368c01d471"},
+    {file = "numpy-1.22.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:47ee7a839f5885bc0c63a74aabb91f6f40d7d7b639253768c4199b37aede7982"},
+    {file = "numpy-1.22.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a024181d7aef0004d76fb3bce2a4c9f2e67a609a9e2a6ff2571d30e9976aa383"},
+    {file = "numpy-1.22.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f71d57cc8645f14816ae249407d309be250ad8de93ef61d9709b45a0ddf4050c"},
+    {file = "numpy-1.22.0-cp38-cp38-win32.whl", hash = "sha256:283d9de87c0133ef98f93dfc09fad3fb382f2a15580de75c02b5bb36a5a159a5"},
+    {file = "numpy-1.22.0-cp38-cp38-win_amd64.whl", hash = "sha256:2762331de395739c91f1abb88041f94a080cb1143aeec791b3b223976228af3f"},
+    {file = "numpy-1.22.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:76ba7c40e80f9dc815c5e896330700fd6e20814e69da9c1267d65a4d051080f1"},
+    {file = "numpy-1.22.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0cfe07133fd00b27edee5e6385e333e9eeb010607e8a46e1cd673f05f8596595"},
+    {file = "numpy-1.22.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6ed0d073a9c54ac40c41a9c2d53fcc3d4d4ed607670b9e7b0de1ba13b4cbfe6f"},
+    {file = "numpy-1.22.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41388e32e40b41dd56eb37fcaa7488b2b47b0adf77c66154d6b89622c110dfe9"},
+    {file = "numpy-1.22.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b55b953a1bdb465f4dc181758570d321db4ac23005f90ffd2b434cc6609a63dd"},
+    {file = "numpy-1.22.0-cp39-cp39-win32.whl", hash = "sha256:5a311ee4d983c487a0ab546708edbdd759393a3dc9cd30305170149fedd23c88"},
+    {file = "numpy-1.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:a97a954a8c2f046d3817c2bce16e3c7e9a9c2afffaf0400f5c16df5172a67c9c"},
+    {file = "numpy-1.22.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb02929b0d6bfab4c48a79bd805bd7419114606947ec8284476167415171f55b"},
+    {file = "numpy-1.22.0.zip", hash = "sha256:a955e4128ac36797aaffd49ab44ec74a71c11d6938df83b1285492d277db5397"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pandas = [
-    {file = "pandas-1.3.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9707bdc1ea9639c886b4d3be6e2a45812c1ac0c2080f94c31b71c9fa35556f9b"},
-    {file = "pandas-1.3.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c2f44425594ae85e119459bb5abb0748d76ef01d9c08583a667e3339e134218e"},
-    {file = "pandas-1.3.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:372d72a3d8a5f2dbaf566a5fa5fa7f230842ac80f29a931fb4b071502cf86b9a"},
-    {file = "pandas-1.3.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d99d2350adb7b6c3f7f8f0e5dfb7d34ff8dd4bc0a53e62c445b7e43e163fce63"},
-    {file = "pandas-1.3.4-cp310-cp310-win_amd64.whl", hash = "sha256:4acc28364863127bca1029fb72228e6f473bb50c32e77155e80b410e2068eeac"},
-    {file = "pandas-1.3.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c2646458e1dce44df9f71a01dc65f7e8fa4307f29e5c0f2f92c97f47a5bf22f5"},
-    {file = "pandas-1.3.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5298a733e5bfbb761181fd4672c36d0c627320eb999c59c65156c6a90c7e1b4f"},
-    {file = "pandas-1.3.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22808afb8f96e2269dcc5b846decacb2f526dd0b47baebc63d913bf847317c8f"},
-    {file = "pandas-1.3.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b528e126c13816a4374e56b7b18bfe91f7a7f6576d1aadba5dee6a87a7f479ae"},
-    {file = "pandas-1.3.4-cp37-cp37m-win32.whl", hash = "sha256:fe48e4925455c964db914b958f6e7032d285848b7538a5e1b19aeb26ffaea3ec"},
-    {file = "pandas-1.3.4-cp37-cp37m-win_amd64.whl", hash = "sha256:eaca36a80acaacb8183930e2e5ad7f71539a66805d6204ea88736570b2876a7b"},
-    {file = "pandas-1.3.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:42493f8ae67918bf129869abea8204df899902287a7f5eaf596c8e54e0ac7ff4"},
-    {file = "pandas-1.3.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a388960f979665b447f0847626e40f99af8cf191bce9dc571d716433130cb3a7"},
-    {file = "pandas-1.3.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ba0aac1397e1d7b654fccf263a4798a9e84ef749866060d19e577e927d66e1b"},
-    {file = "pandas-1.3.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f567e972dce3bbc3a8076e0b675273b4a9e8576ac629149cf8286ee13c259ae5"},
-    {file = "pandas-1.3.4-cp38-cp38-win32.whl", hash = "sha256:c1aa4de4919358c5ef119f6377bc5964b3a7023c23e845d9db7d9016fa0c5b1c"},
-    {file = "pandas-1.3.4-cp38-cp38-win_amd64.whl", hash = "sha256:dd324f8ee05925ee85de0ea3f0d66e1362e8c80799eb4eb04927d32335a3e44a"},
-    {file = "pandas-1.3.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d47750cf07dee6b55d8423471be70d627314277976ff2edd1381f02d52dbadf9"},
-    {file = "pandas-1.3.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d1dc09c0013d8faa7474574d61b575f9af6257ab95c93dcf33a14fd8d2c1bab"},
-    {file = "pandas-1.3.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10e10a2527db79af6e830c3d5842a4d60383b162885270f8cffc15abca4ba4a9"},
-    {file = "pandas-1.3.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35c77609acd2e4d517da41bae0c11c70d31c87aae8dd1aabd2670906c6d2c143"},
-    {file = "pandas-1.3.4-cp39-cp39-win32.whl", hash = "sha256:003ba92db58b71a5f8add604a17a059f3068ef4e8c0c365b088468d0d64935fd"},
-    {file = "pandas-1.3.4-cp39-cp39-win_amd64.whl", hash = "sha256:a51528192755f7429c5bcc9e80832c517340317c861318fea9cea081b57c9afd"},
-    {file = "pandas-1.3.4.tar.gz", hash = "sha256:a2aa18d3f0b7d538e21932f637fbfe8518d085238b429e4790a35e1e44a96ffc"},
+    {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:62d5b5ce965bae78f12c1c0df0d387899dd4211ec0bdc52822373f13a3a022b9"},
+    {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:adfeb11be2d54f275142c8ba9bf67acee771b7186a5745249c7d5a06c670136b"},
+    {file = "pandas-1.3.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:60a8c055d58873ad81cae290d974d13dd479b82cbb975c3e1fa2cf1920715296"},
+    {file = "pandas-1.3.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd541ab09e1f80a2a1760032d665f6e032d8e44055d602d65eeea6e6e85498cb"},
+    {file = "pandas-1.3.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2651d75b9a167cc8cc572cf787ab512d16e316ae00ba81874b560586fa1325e0"},
+    {file = "pandas-1.3.5-cp310-cp310-win_amd64.whl", hash = "sha256:aaf183a615ad790801fa3cf2fa450e5b6d23a54684fe386f7e3208f8b9bfbef6"},
+    {file = "pandas-1.3.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:344295811e67f8200de2390093aeb3c8309f5648951b684d8db7eee7d1c81fb7"},
+    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:552020bf83b7f9033b57cbae65589c01e7ef1544416122da0c79140c93288f56"},
+    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cce0c6bbeb266b0e39e35176ee615ce3585233092f685b6a82362523e59e5b4"},
+    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d28a3c65463fd0d0ba8bbb7696b23073efee0510783340a44b08f5e96ffce0c"},
+    {file = "pandas-1.3.5-cp37-cp37m-win32.whl", hash = "sha256:a62949c626dd0ef7de11de34b44c6475db76995c2064e2d99c6498c3dba7fe58"},
+    {file = "pandas-1.3.5-cp37-cp37m-win_amd64.whl", hash = "sha256:8025750767e138320b15ca16d70d5cdc1886e8f9cc56652d89735c016cd8aea6"},
+    {file = "pandas-1.3.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fe95bae4e2d579812865db2212bb733144e34d0c6785c0685329e5b60fcb85dd"},
+    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f261553a1e9c65b7a310302b9dbac31cf0049a51695c14ebe04e4bfd4a96f02"},
+    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b6dbec5f3e6d5dc80dcfee250e0a2a652b3f28663492f7dab9a24416a48ac39"},
+    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3bc49af96cd6285030a64779de5b3688633a07eb75c124b0747134a63f4c05f"},
+    {file = "pandas-1.3.5-cp38-cp38-win32.whl", hash = "sha256:b6b87b2fb39e6383ca28e2829cddef1d9fc9e27e55ad91ca9c435572cdba51bf"},
+    {file = "pandas-1.3.5-cp38-cp38-win_amd64.whl", hash = "sha256:a395692046fd8ce1edb4c6295c35184ae0c2bbe787ecbe384251da609e27edcb"},
+    {file = "pandas-1.3.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bd971a3f08b745a75a86c00b97f3007c2ea175951286cdda6abe543e687e5f2f"},
+    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37f06b59e5bc05711a518aa10beaec10942188dccb48918bb5ae602ccbc9f1a0"},
+    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c21778a688d3712d35710501f8001cdbf96eb70a7c587a3d5613573299fdca6"},
+    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3345343206546545bc26a05b4602b6a24385b5ec7c75cb6059599e3d56831da2"},
+    {file = "pandas-1.3.5-cp39-cp39-win32.whl", hash = "sha256:c69406a2808ba6cf580c2255bcf260b3f214d2664a3a4197d0e640f573b46fd3"},
+    {file = "pandas-1.3.5-cp39-cp39-win_amd64.whl", hash = "sha256:32e1a26d5ade11b547721a72f9bfc4bd113396947606e00d5b4a5b79b3dcb006"},
+    {file = "pandas-1.3.5.tar.gz", hash = "sha256:1e4285f5de1012de20ca46b188ccf33521bff61ba5c5ebd78b4fb28e5416a9f1"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
@@ -1246,8 +1222,8 @@ pbr = [
     {file = "pbr-5.8.0.tar.gz", hash = "sha256:672d8ebee84921862110f23fcec2acea191ef58543d34dfe9ef3d9f13c31cddf"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
-    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
+    {file = "platformdirs-2.4.1-py3-none-any.whl", hash = "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca"},
+    {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -1358,8 +1334,8 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 requests = [
-    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
-    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+    {file = "requests-2.27.0-py2.py3-none-any.whl", hash = "sha256:f71a09d7feba4a6b64ffd8e9d9bc60f9bf7d7e19fd0e04362acb1cfc2e3d98df"},
+    {file = "requests-2.27.0.tar.gz", hash = "sha256:8e5643905bf20a308e25e4c1dd379117c09000bf8a82ebccc462cfb1b34a16b5"},
 ]
 safety = [
     {file = "safety-1.10.3-py2.py3-none-any.whl", hash = "sha256:5f802ad5df5614f9622d8d71fedec2757099705c2356f862847c58c6dfe13e84"},
@@ -1413,8 +1389,8 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-1.2.2-py3-none-any.whl", hash = "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"},
-    {file = "tomli-1.2.2.tar.gz", hash = "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee"},
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
@@ -1425,6 +1401,6 @@ urllib3 = [
     {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.10.0-py2.py3-none-any.whl", hash = "sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814"},
-    {file = "virtualenv-20.10.0.tar.gz", hash = "sha256:576d05b46eace16a9c348085f7d0dc8ef28713a2cabaa1cf0aea41e8f12c9218"},
+    {file = "virtualenv-20.13.0-py2.py3-none-any.whl", hash = "sha256:339f16c4a86b44240ba7223d0f93a7887c3ca04b5f9c8129da7958447d079b09"},
+    {file = "virtualenv-20.13.0.tar.gz", hash = "sha256:d8458cf8d59d0ea495ad9b34c2599487f8a7772d796f9910858376d1600dd2dd"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ authors = ["Ed Fawcett-Taylor <ed.fawcett-taylor@defra.gov.uk>"]
 [tool.poetry.dependencies]
 python = "^3.8"
 pyspark = "3.0.1"
-GDAL = "3.4.0"
 more-itertools = "^8.12.0"
 pandas = "^1.3.4"
+GDAL = "3.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Ed Fawcett-Taylor <ed.fawcett-taylor@defra.gov.uk>"]
 [tool.poetry.dependencies]
 python = "^3.8"
 pyspark = "3.0.1"
-GDAL = "3.3.2"
+GDAL = "3.4.0"
 more-itertools = "^8.12.0"
 pandas = "^1.3.4"
 

--- a/src/esa_geo_utils/io/__init__.py
+++ b/src/esa_geo_utils/io/__init__.py
@@ -224,8 +224,8 @@ def read_vector_files(
             )
 
             return (
-                df.repartition(number_of_partitions, "id")
-                .groupby("id")
+                df.repartition(number_of_partitions, "path")
+                .groupby("path")
                 .applyInPandas(parallel_read, _schema)
             )
 

--- a/src/esa_geo_utils/io/__init__.py
+++ b/src/esa_geo_utils/io/__init__.py
@@ -27,17 +27,24 @@ from pyspark.sql.types import (
 
 from esa_geo_utils.io._create_initial_df import (
     _add_vsi_prefix,
-    _create_initial_df,
+    _create_chunks_df,
+    _create_paths_df,
     _get_data_sources,
     _get_feature_counts,
-    _get_layer_name,
     _get_layer_names,
     _get_paths,
     _get_sequence_of_chunks,
     _get_total_chunks,
 )
-from esa_geo_utils.io._create_schema import _create_schema
-from esa_geo_utils.io._generate_parallel_reader import _generate_parallel_reader
+from esa_geo_utils.io._create_schema import (
+    _create_schema_for_chunks,
+    _create_schema_for_files,
+)
+from esa_geo_utils.io._generate_parallel_reader import (
+    _generate_parallel_reader_for_chunks,
+    _generate_parallel_reader_for_files,
+)
+from esa_geo_utils.io._types import ConcurrencyStrategy
 
 # See:
 # https://gdal.org/python/index.html
@@ -99,7 +106,6 @@ def read_vector_files(
     ogr_to_spark_type_map: MappingProxyType = OGR_TO_SPARK,
     spark: SparkSession = SparkSession._activeSession,
     suffix: str = "*",
-    chunk: bool = True,
     ideal_chunk_size: int = 3_000_000,
     geom_field_name: str = "geometry",
     geom_field_type: str = "Binary",
@@ -108,7 +114,7 @@ def read_vector_files(
     vsi_prefix: Optional[str] = None,
     schema: StructType = None,
     layer_identifier: Optional[Union[str, int]] = None,
-    check_layer_name: bool = True,
+    concurrency_strategy: str = "files",
 ) -> SparkDataFrame:
     """Read vector file(s) into a Spark DataFrame.
 
@@ -156,7 +162,6 @@ def read_vector_files(
         spark (SparkSession): [description]. Defaults to
             SparkSession._activeSession.
         suffix (str): [description]. Defaults to "*".
-        chunk (bool): [description]. Defaults to True.
         ideal_chunk_size (int): [description]. Defaults to 3_000_000.
         geom_field_name (str): [description]. Defaults to "geometry".
         geom_field_type (str): [description]. Defaults to "Binary".
@@ -166,11 +171,13 @@ def read_vector_files(
         vsi_prefix (str, optional): [description]. Defaults to None.
         schema (StructType): [description]. Defaults to None.
         layer_identifier (str, optional): [description]. Defaults to None.
-        check_layer_name (bool): [description]. Defaults to True.
+        concurrency_strategy (str): [description]. Defaults to "files".
 
     Returns:
         SparkDataFrame: [description]
     """
+    _concurrency_strategy = ConcurrencyStrategy(concurrency_strategy)
+
     paths = _get_paths(
         path=path,
         suffix=suffix,
@@ -182,23 +189,54 @@ def read_vector_files(
             vsi_prefix=vsi_prefix,
         )
 
-    if check_layer_name:
+    if _concurrency_strategy == ConcurrencyStrategy.FILES:
+
+        number_of_partitions = len(paths)
+
+        with temporary_spark_context(
+            configuration_key="spark.sql.shuffle.partitions",
+            new_configuration_value=number_of_partitions,
+        ) as spark:
+
+            df = _create_paths_df(
+                spark=spark,
+                paths=paths,
+            )
+
+            _schema = (
+                schema
+                if schema
+                else _create_schema_for_files(
+                    path=paths[0],
+                    layer_identifier=layer_identifier,
+                    ogr_to_spark_type_map=ogr_to_spark_type_map,
+                    geom_field_name=geom_field_name,
+                    geom_field_type=geom_field_type,
+                )
+            )
+
+            parallel_read = _generate_parallel_reader_for_files(
+                layer_identifier=layer_identifier,
+                geom_field_name=geom_field_name,
+                coerce_to_schema=coerce_to_schema,
+                spark_to_pandas_type_map=spark_to_pandas_type_map,
+                schema=_schema,
+            )
+
+            return (
+                df.repartition(number_of_partitions, "id")
+                .groupby("id")
+                .applyInPandas(parallel_read, _schema)
+            )
+
+    else:
         data_sources = _get_data_sources(paths)
 
         layer_names = _get_layer_names(
             data_sources=data_sources,
             layer_identifier=layer_identifier,
         )
-    else:
-        data_source = _get_data_sources((paths[0],))
 
-        layer_name = _get_layer_names(
-            data_sources=data_source,
-            layer_identifier=layer_identifier,
-        )
-        layer_names = layer_name * len(paths)
-
-    if chunk:
         feature_counts = _get_feature_counts(
             data_sources=data_sources,
             layer_names=layer_names,
@@ -210,43 +248,40 @@ def read_vector_files(
         )
 
         number_of_partitions = _get_total_chunks(sequence_of_chunks)
-    else:
-        sequence_of_chunks = (((None, None),),) * len(paths)
-        number_of_partitions = len(paths)
 
-    with temporary_spark_context(
-        configuration_key="spark.sql.shuffle.partitions",
-        new_configuration_value=number_of_partitions,
-    ) as spark:
+        with temporary_spark_context(
+            configuration_key="spark.sql.shuffle.partitions",
+            new_configuration_value=number_of_partitions,
+        ) as spark:
 
-        df = _create_initial_df(
-            spark=spark,
-            paths=paths,
-            layer_names=layer_names,
-            sequence_of_chunks=sequence_of_chunks,
-        )
-
-        _schema = (
-            schema
-            if schema
-            else _create_schema(
-                data_source=data_sources[0],
-                layer_name=layer_names[0],
-                ogr_to_spark_type_map=ogr_to_spark_type_map,
-                geom_field_name=geom_field_name,
-                geom_field_type=geom_field_type,
+            df = _create_chunks_df(
+                spark=spark,
+                paths=paths,
+                layer_names=layer_names,
+                sequence_of_chunks=sequence_of_chunks,
             )
-        )
 
-        parallel_read = _generate_parallel_reader(
-            geom_field_name=geom_field_name,
-            coerce_to_schema=coerce_to_schema,
-            spark_to_pandas_type_map=spark_to_pandas_type_map,
-            schema=_schema,
-        )
+            _schema = (
+                schema
+                if schema
+                else _create_schema_for_chunks(
+                    data_source=data_sources[0],
+                    layer_name=layer_names[0],
+                    ogr_to_spark_type_map=ogr_to_spark_type_map,
+                    geom_field_name=geom_field_name,
+                    geom_field_type=geom_field_type,
+                )
+            )
 
-        return (
-            df.repartition(number_of_partitions, "chunk_id")
-            .groupby("chunk_id")
-            .applyInPandas(parallel_read, _schema)
-        )
+            parallel_read = _generate_parallel_reader_for_chunks(
+                geom_field_name=geom_field_name,
+                coerce_to_schema=coerce_to_schema,
+                spark_to_pandas_type_map=spark_to_pandas_type_map,
+                schema=_schema,
+            )
+
+            return (
+                df.repartition(number_of_partitions, "id")
+                .groupby("id")
+                .applyInPandas(parallel_read, _schema)
+            )

--- a/src/esa_geo_utils/io/__init__.py
+++ b/src/esa_geo_utils/io/__init__.py
@@ -11,8 +11,7 @@ from contextlib import contextmanager
 from types import MappingProxyType
 from typing import Optional, Union
 
-from numpy import float32, object0
-from pandas import Int32Dtype, Int64Dtype, StringDtype
+from numpy import float32, int32, int64, object0
 from pyspark.sql import DataFrame as SparkDataFrame
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (
@@ -79,9 +78,9 @@ SPARK_TO_PANDAS = MappingProxyType(
         ArrayType(StringType()): object0,
         BinaryType(): object0,
         FloatType(): float32,
-        IntegerType(): Int32Dtype(),
-        LongType(): Int64Dtype(),
-        StringType(): StringDtype(),
+        IntegerType(): int32,
+        LongType(): int64,
+        StringType(): object0,
     }
 )
 

--- a/src/esa_geo_utils/io/__init__.py
+++ b/src/esa_geo_utils/io/__init__.py
@@ -79,7 +79,7 @@ SPARK_TO_PANDAS = MappingProxyType(
 
 
 @contextmanager
-def local_spark_context(
+def temporary_spark_context(
     configuration_key: str,
     new_configuration_value: Union[str, int],
     spark: SparkSession = SparkSession._activeSession,
@@ -196,7 +196,7 @@ def read_vector_files(
 
     total_chunks = _get_total_chunks(sequence_of_chunks)
 
-    with local_spark_context(
+    with temporary_spark_context(
         configuration_key="spark.sql.shuffle.partitions",
         new_configuration_value=total_chunks,
     ) as spark:

--- a/src/esa_geo_utils/io/_create_initial_df.py
+++ b/src/esa_geo_utils/io/_create_initial_df.py
@@ -127,9 +127,11 @@ def _get_feature_counts(
     )
 
 
-def _get_chunks(
-    feature_count: int, ideal_chunk_size: int
-) -> Tuple[Tuple[int, int], ...]:
+Chunk = Union[Tuple[int, int], Tuple[None, None]]
+Chunks = Tuple[Chunk, ...]
+
+
+def _get_chunks(feature_count: int, ideal_chunk_size: int) -> Chunks:
     exclusive_range = range(0, feature_count, ideal_chunk_size)
     inclusive_range = tuple(exclusive_range) + (feature_count + 1,)
     range_pairs = pairwise(inclusive_range)
@@ -139,16 +141,14 @@ def _get_chunks(
 def _get_sequence_of_chunks(
     feature_counts: Tuple[int, ...],
     ideal_chunk_size: int,
-) -> Tuple[Tuple[Tuple[int, int], ...], ...]:
+) -> Tuple[Chunks, ...]:
     return tuple(
         _get_chunks(feature_count=feature_count, ideal_chunk_size=ideal_chunk_size)
         for feature_count in feature_counts
     )
 
 
-def _get_total_chunks(
-    sequence_of_chunks: Tuple[Tuple[Tuple[int, int], ...], ...]
-) -> int:
+def _get_total_chunks(sequence_of_chunks: Tuple[Chunks, ...]) -> int:
     return sum(len(chunks) for chunks in sequence_of_chunks)
 
 
@@ -156,7 +156,7 @@ def _create_initial_df(
     spark: SparkSession,
     paths: Tuple[str, ...],
     layer_names: Tuple[str, ...],
-    sequence_of_chunks: Tuple[Tuple[Tuple[int, int], ...], ...],
+    sequence_of_chunks: Tuple[Chunks, ...],
 ) -> SparkDataFrame:
     rows = tuple(
         Row(

--- a/src/esa_geo_utils/io/_create_schema.py
+++ b/src/esa_geo_utils/io/_create_schema.py
@@ -75,7 +75,8 @@ def _create_schema_for_files(
     data_source = Open(path)
 
     layer_name = _get_layer_name(
-        layer_identifier=layer_identifier,
+        # ! first argument to singledispatch function must be positional
+        layer_identifier,
         data_source=data_source,
     )
 

--- a/src/esa_geo_utils/io/_generate_parallel_reader.py
+++ b/src/esa_geo_utils/io/_generate_parallel_reader.py
@@ -199,10 +199,7 @@ def _pdf_from_vector_file(
             data_source=data_source,
         )
     except ValueError:
-        return _null_data_frame_from_schema(
-            schema=schema,
-            spark_to_pandas_type_map=spark_to_pandas_type_map,
-        )
+        return None
 
     layer = _get_layer(
         data_source=data_source,

--- a/src/esa_geo_utils/io/_generate_parallel_reader.py
+++ b/src/esa_geo_utils/io/_generate_parallel_reader.py
@@ -199,7 +199,10 @@ def _pdf_from_vector_file(
             data_source=data_source,
         )
     except ValueError:
-        return None
+        return _null_data_frame_from_schema(
+            schema=schema,
+            spark_to_pandas_type_map=spark_to_pandas_type_map,
+        )
 
     layer = _get_layer(
         data_source=data_source,

--- a/src/esa_geo_utils/io/_generate_parallel_reader.py
+++ b/src/esa_geo_utils/io/_generate_parallel_reader.py
@@ -103,12 +103,13 @@ def _add_missing_columns(
     spark_to_pandas_type_map: MappingProxyType,
 ) -> PandasDataFrame:
     """Adds missing fields to pandas DataFrame."""
-    to_add = compress(schema_field_names, missing_columns)
+    to_add = compress(schema_field_details, missing_columns)
     missing_column_series = tuple(
         Series(
             name=field_name,
+            dtype=spark_to_pandas_type_map[field_type],
         )
-        for field_name in to_add
+        for field_name, field_type in to_add
     )
     pdf_plus_missing_columns = pdf.append(missing_column_series)
     reindexed_pdf = pdf_plus_missing_columns.reindex(columns=schema_field_names)

--- a/src/esa_geo_utils/io/_generate_parallel_reader.py
+++ b/src/esa_geo_utils/io/_generate_parallel_reader.py
@@ -200,10 +200,6 @@ def _pdf_from_vector_file(
         )
     except ValueError as error:
         print(f"Error for {path}: {error}")
-        return _null_data_frame_from_schema(
-            schema=schema,
-            spark_to_pandas_type_map=spark_to_pandas_type_map,
-        )
 
     layer = _get_layer(
         data_source=data_source,

--- a/src/esa_geo_utils/io/_generate_parallel_reader.py
+++ b/src/esa_geo_utils/io/_generate_parallel_reader.py
@@ -191,11 +191,18 @@ def _pdf_from_vector_file(
             spark_to_pandas_type_map=spark_to_pandas_type_map,
         )
 
-    layer_name = _get_layer_name(
-        # ! first argument to singledispatch function must be positional
-        layer_identifier,
-        data_source=data_source,
-    )
+    try:
+        layer_name = _get_layer_name(
+            # ! first argument to singledispatch function must be positional
+            layer_identifier,
+            data_source=data_source,
+        )
+    except ValueError as error:
+        print(f"Error for {path}: {error}")
+        return _null_data_frame_from_schema(
+            schema=schema,
+            spark_to_pandas_type_map=spark_to_pandas_type_map,
+        )
 
     layer = _get_layer(
         data_source=data_source,

--- a/src/esa_geo_utils/io/_generate_parallel_reader.py
+++ b/src/esa_geo_utils/io/_generate_parallel_reader.py
@@ -192,7 +192,8 @@ def _pdf_from_vector_file(
         )
 
     layer_name = _get_layer_name(
-        layer_identifier=layer_identifier,
+        # ! first argument to singledispatch function must be positional
+        layer_identifier,
         data_source=data_source,
     )
 

--- a/src/esa_geo_utils/io/_generate_parallel_reader.py
+++ b/src/esa_geo_utils/io/_generate_parallel_reader.py
@@ -198,8 +198,11 @@ def _pdf_from_vector_file(
             layer_identifier,
             data_source=data_source,
         )
-    except ValueError as error:
-        print(f"Error for {path}: {error}")
+    except ValueError:
+        return _null_data_frame_from_schema(
+            schema=schema,
+            spark_to_pandas_type_map=spark_to_pandas_type_map,
+        )
 
     layer = _get_layer(
         data_source=data_source,

--- a/src/esa_geo_utils/io/_types.py
+++ b/src/esa_geo_utils/io/_types.py
@@ -1,0 +1,13 @@
+from enum import Enum
+from typing import Tuple, Union
+
+
+class ConcurrencyStrategy(Enum):
+    """Valid concurrency strategies."""
+
+    FILES = "files"
+    ROWS = "rows"
+
+
+Chunk = Union[Tuple[int, int], Tuple[None, None]]
+Chunks = Tuple[Chunk, ...]

--- a/src/esa_geo_utils/io/_types.py
+++ b/src/esa_geo_utils/io/_types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Tuple, Union
+from typing import Tuple
 
 
 class ConcurrencyStrategy(Enum):
@@ -9,5 +9,5 @@ class ConcurrencyStrategy(Enum):
     ROWS = "rows"
 
 
-Chunk = Union[Tuple[int, int], Tuple[None, None]]
+Chunk = Tuple[int, int]
 Chunks = Tuple[Chunk, ...]

--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -5,8 +5,9 @@ from typing import Tuple
 
 from _pytest.tmpdir import TempPathFactory
 from geopandas import GeoDataFrame
+from numpy import int64, object0
 from pandas import DataFrame as PandasDataFrame
-from pandas import Int64Dtype, Series, StringDtype
+from pandas import Series
 from pyspark.sql.types import (
     BinaryType,
     DataType,
@@ -33,7 +34,7 @@ def layer_column_names_missing_column(
     layer_column_names: Tuple[str, ...]
 ) -> Tuple[str, ...]:
     """Shared column names but missing `id` column."""
-    return tuple(name for name in layer_column_names if name != "id")
+    return tuple(name for name in layer_column_names if name != "category")
 
 
 @fixture
@@ -72,8 +73,8 @@ def first_layer_gdf(
         crs="EPSG:27700",
     ).astype(
         {
-            "id": Int64Dtype(),
-            "category": StringDtype(),
+            "id": int64,
+            "category": object0,
         },
     )
 
@@ -93,9 +94,9 @@ def first_layer_pdf(
 def first_layer_pdf_with_missing_column(
     first_layer_pdf: PandasDataFrame,
 ) -> PandasDataFrame:
-    """First layer pdf with missing 'id' column."""
+    """First layer pdf with missing 'category' column."""
     return first_layer_pdf.drop(
-        columns=["id"],
+        columns=["category"],
     )
 
 

--- a/tests/io/test__create_schema.py
+++ b/tests/io/test__create_schema.py
@@ -7,7 +7,8 @@ from osgeo.ogr import Layer, Open
 from pyspark.sql.types import StructType
 
 from esa_geo_utils.io._create_schema import (
-    _create_schema,
+    _create_schema_for_chunks,
+    _create_schema_for_files,
     _get_feature_schema,
     _get_layer,
     _get_property_names,
@@ -89,7 +90,7 @@ def test__get_feature_schema(
     assert schema == fileGDB_schema
 
 
-def test__create_schema(
+def test__create_schema_for_chunks(
     fileGDB_path: str,
     fileGDB_schema: StructType,
     ogr_to_spark_mapping: MappingProxyType,
@@ -97,9 +98,25 @@ def test__create_schema(
     """Returns expected Spark schema regardless of `_get_layer` function used."""
     data_source = Open(fileGDB_path)
 
-    schema = _create_schema(
+    schema = _create_schema_for_chunks(
         data_source=data_source,
         layer_name="first",
+        geom_field_name="geometry",
+        geom_field_type="Binary",
+        ogr_to_spark_type_map=ogr_to_spark_mapping,
+    )
+    assert schema == fileGDB_schema
+
+
+def test__create_schema_for_files(
+    fileGDB_path: str,
+    fileGDB_schema: StructType,
+    ogr_to_spark_mapping: MappingProxyType,
+) -> None:
+    """Returns expected Spark schema regardless of `_get_layer` function used."""
+    schema = _create_schema_for_files(
+        path=fileGDB_path,
+        layer_identifier="first",
         geom_field_name="geometry",
         geom_field_type="Binary",
         ogr_to_spark_type_map=ogr_to_spark_mapping,

--- a/tests/io/test__generate_parallel_reader.py
+++ b/tests/io/test__generate_parallel_reader.py
@@ -92,7 +92,7 @@ def test__get_columns_names(
     ],
     argvalues=[
         ("layer_column_names", (False, False, False)),
-        ("layer_column_names_missing_column", (True, False, False)),
+        ("layer_column_names_missing_column", (False, True, False)),
     ],
     ids=[
         "Same column names",


### PR DESCRIPTION
- Updates dependencies, including GDAL to 3.4.0
- Allows caller to chose between file and chunk based concurrency
- Drops use of nullable pandas types
- Closes #14 by using context manager to change shuffle partitions temporarily
- Adds type aliases for more concise function signatures
- Adds tests for `_create_schema_for_chunks` and `_create_schema_for_files`
- Tests for missing category column to avoid conversion between pandas nullable integer and spark integer types